### PR TITLE
feat: add remote repo support and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.venv/
+.egg-info/
+build/
+dist/
+*.coverage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# uithub-local
+
+Flatten a local or remote Git repository into a single text dump with an approximate token count.
+
+## Quick Start
+
+```bash
+pip install .
+
+uithub path/to/repo --include "*.py" --exclude "tests/*"
+
+# remote repo
+uithub --remote-url https://github.com/user/private --private-token $GITHUB_TOKEN --no-stdout
+```
+
+## Usage
+
+Run `uithub --help` for all options. The dump can be printed to STDOUT or saved to a file. JSON output is available using `--format json`. Use `--remote-url` and optionally `--private-token` to process remote repositories.
+
+## Tests
+
+Install dev dependencies and run:
+
+```bash
+pip install .[test]
+make test
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "uithub-local"
+version = "0.1.0"
+description = "Local Uithub CLI to flatten Git repositories into text dumps."
+authors = [{name = "Codex", email = "codex@example.com"}]
+requires-python = ">=3.11"
+dependencies = [
+    "click>=8",
+    "tiktoken>=0.5",
+    "requests>=2.31",
+]
+
+[project.scripts]
+uithub = "uithub_local.cli:main"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+    "freezegun>=1.4",
+    "responses",
+]
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "--cov=uithub_local -q"

--- a/src/uithub_local/__init__.py
+++ b/src/uithub_local/__init__.py
@@ -1,0 +1,10 @@
+"""Local Uithub package."""
+
+__all__ = [
+    "cli",
+    "loader",
+    "renderer",
+    "downloader",
+    "tokenizer",
+    "walker",
+]

--- a/src/uithub_local/cli.py
+++ b/src/uithub_local/cli.py
@@ -1,0 +1,80 @@
+"""CLI entry point for uithub-local."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import click
+
+from .downloader import download_repo
+from .renderer import render
+from .walker import collect_files
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument(
+    "path",
+    required=False,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option("--remote-url", help="Download and use remote repository")
+@click.option(
+    "--private-token",
+    envvar="GITHUB_TOKEN",
+    help="Token for private repository",
+)
+@click.option("--include", multiple=True, default=["*"], help="Glob(s) to include")
+@click.option("--exclude", multiple=True, help="Glob(s) to exclude")
+@click.option("--max-tokens", type=int, help="Hard cap; truncate largest files first")
+@click.option(
+    "--max-size",
+    type=int,
+    default=1_048_576,
+    show_default=True,
+    help="Skip files larger than this size (bytes)",
+)
+@click.option("--format", "fmt", type=click.Choice(["text", "json"]), default="text")
+@click.option("--stdout/--no-stdout", default=True, help="Print dump to STDOUT")
+@click.option("--outfile", type=click.Path(path_type=Path), help="Write dump to file")
+@click.version_option()
+def main(
+    path: Path | None,
+    remote_url: str | None,
+    private_token: str | None,
+    include: List[str],
+    exclude: List[str],
+    max_tokens: int | None,
+    max_size: int,
+    fmt: str,
+    stdout: bool,
+    outfile: Path | None,
+) -> None:
+    """Flatten a repository into one text dump."""
+
+    if not path and not remote_url:
+        raise click.UsageError("Provide PATH or --remote-url")
+    if path and remote_url:
+        raise click.UsageError("Cannot combine PATH and --remote-url")
+
+    try:
+        if remote_url:
+            with download_repo(remote_url, private_token) as tmp:
+                files = collect_files(tmp, include, exclude, max_size=max_size)
+                output = render(files, tmp, max_tokens=max_tokens, fmt=fmt)
+        else:
+            assert path is not None
+            files = collect_files(path, include, exclude, max_size=max_size)
+            output = render(files, path, max_tokens=max_tokens, fmt=fmt)
+    except Exception as exc:  # pragma: no cover - fatal CLI errors
+        click.echo(str(exc), err=True)
+        raise SystemExit(1)
+
+    if outfile:
+        outfile.write_text(output)
+    if stdout:
+        click.echo(output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/uithub_local/downloader.py
+++ b/src/uithub_local/downloader.py
@@ -1,0 +1,47 @@
+"""Remote repository downloader."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Iterator
+
+import requests  # type: ignore
+
+
+def _zip_url(remote_url: str, branch: str = "main", private: bool = False) -> str:
+    if remote_url.endswith(".git"):
+        remote_url = remote_url[:-4]
+    if remote_url.startswith("https://"):
+        base = remote_url
+    else:
+        base = f"https://github.com/{remote_url}"
+
+    if "github.com" in base:
+        if private:
+            return f"https://api.github.com/repos/{base.split('github.com/')[-1]}/zipball/{branch}"
+        return f"{base}/archive/refs/heads/{branch}.zip"
+    if "bitbucket.org" in base:
+        return f"{base}/get/{branch}.zip"
+    raise ValueError("Unsupported remote host")
+
+
+@contextlib.contextmanager
+def download_repo(remote_url: str, token: str | None = None) -> Iterator[Path]:
+    """Yield a temporary directory with the downloaded repo."""
+
+    private = token is not None
+    url = _zip_url(remote_url, private=private)
+    headers = {"Authorization": f"token {token}"} if token else {}
+    with tempfile.TemporaryDirectory() as td:
+        dest = Path(td)
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = io.BytesIO(resp.content)
+        with zipfile.ZipFile(data) as zf:
+            zf.extractall(dest)
+        roots = [p for p in dest.iterdir() if p.is_dir()]
+        yield roots[0] if len(roots) == 1 else dest

--- a/src/uithub_local/loader.py
+++ b/src/uithub_local/loader.py
@@ -1,0 +1,14 @@
+"""Safe file loader with encoding fallback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_text(path: Path) -> str:
+    """Return text of *path* with UTF-8 fallback."""
+
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")

--- a/src/uithub_local/renderer.py
+++ b/src/uithub_local/renderer.py
@@ -1,0 +1,89 @@
+"""Render repository files into a single dump."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from .loader import load_text
+from .tokenizer import approximate_tokens
+from .walker import FileInfo
+
+
+class FileDump:
+    """A file plus its loaded contents and token count."""
+
+    def __init__(self, info: FileInfo, root: Path) -> None:
+        self.path = info.path
+        self.full_path = root / info.path
+        self.size = info.size
+        self.tokens = 0
+        self.content = ""
+        try:
+            self.content = load_text(self.full_path)
+            self.tokens = approximate_tokens(self.content)
+        except Exception:
+            self.content = ""
+            self.tokens = 0
+
+
+class Dump:
+    def __init__(
+        self,
+        files: List[FileInfo],
+        root: Path,
+        max_tokens: int | None = None,
+    ) -> None:
+        self.root = root
+        self.file_dumps: List[FileDump] = [FileDump(info, root) for info in files]
+        self.total_tokens = sum(fd.tokens for fd in self.file_dumps)
+        if max_tokens is not None and self.total_tokens > max_tokens:
+            self._truncate(max_tokens)
+
+    def _truncate(self, limit: int) -> None:
+        self.file_dumps.sort(key=lambda f: f.tokens, reverse=True)
+        while self.total_tokens > limit and self.file_dumps:
+            victim = self.file_dumps.pop(0)
+            self.total_tokens -= victim.tokens
+
+    def as_text(self, repo_name: str) -> str:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        lines = [f"# Uithub-local dump – {repo_name} – {timestamp}"]
+        lines.append(f"# ≈ {self.total_tokens} tokens")
+        for fd in self.file_dumps:
+            lines.append(f"\n### {fd.path.as_posix()}")
+            lines.append(fd.content)
+        lines.append("")
+        return "\n".join(lines)
+
+    def as_json(self, repo_name: str) -> str:
+        obj = {
+            "repo": repo_name,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "total_tokens": self.total_tokens,
+            "files": [
+                {
+                    "path": fd.path.as_posix(),
+                    "contents": fd.content,
+                    "tokens": fd.tokens,
+                }
+                for fd in self.file_dumps
+            ],
+        }
+        return json.dumps(obj, indent=2)
+
+
+def render(
+    files: List[FileInfo],
+    root: Path,
+    *,
+    max_tokens: int | None = None,
+    fmt: str = "text",
+) -> str:
+    dump = Dump(files, root, max_tokens)
+    repo_name = root.name
+    if fmt == "json":
+        return dump.as_json(repo_name)
+    return dump.as_text(repo_name)

--- a/src/uithub_local/tokenizer.py
+++ b/src/uithub_local/tokenizer.py
@@ -1,0 +1,30 @@
+"""Token counting helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from .loader import load_text
+
+
+def approximate_tokens(text: str) -> int:
+    """Return approximate token count of ``text``."""
+    try:
+        import tiktoken
+
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    except Exception:
+        return max(1, len(text) // 4)
+
+
+def total_tokens(paths: Iterable[Path]) -> int:
+    """Return total tokens for ``paths``."""
+    total = 0
+    for path in paths:
+        try:
+            total += approximate_tokens(load_text(path))
+        except Exception:
+            continue
+    return total

--- a/src/uithub_local/utils.py
+++ b/src/uithub_local/utils.py
@@ -1,0 +1,22 @@
+"""Utility helpers for uithub-local."""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+
+def is_binary_path(path: Path) -> bool:
+    """Return True if file looks binary."""
+    mime, _ = mimetypes.guess_type(path.as_posix())
+    if mime is not None and not mime.startswith("text"):
+        return True
+    try:
+        with open(path, "rb") as fh:
+            chunk = fh.read(8192)
+        if b"\0" in chunk:
+            return True
+        non_text = sum(byte < 9 or 14 <= byte < 32 or byte > 127 for byte in chunk)
+        return non_text / len(chunk) > 0.3 if chunk else False
+    except OSError:
+        return True

--- a/src/uithub_local/walker.py
+++ b/src/uithub_local/walker.py
@@ -1,0 +1,67 @@
+"""Collects file paths and metadata."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from .utils import is_binary_path
+
+DEFAULT_MAX_SIZE = 1_048_576  # 1 MiB
+
+
+@dataclass
+class FileInfo:
+    """Metadata about a file in the repository."""
+
+    path: Path
+    size: int
+    mtime: float
+
+
+def collect_files(
+    path: Path,
+    include: Iterable[str] | None = None,
+    exclude: Iterable[str] | None = None,
+    *,
+    max_size: int = DEFAULT_MAX_SIZE,
+) -> List[FileInfo]:
+    """Return list of readable, non-binary files under *path*.
+
+    Parameters
+    ----------
+    path:
+        Directory to walk.
+    include:
+        Glob patterns to include.
+    exclude:
+        Glob patterns to exclude.
+    """
+    include = list(include or ["*"])
+    exclude = list(exclude or [])
+    files: List[FileInfo] = []
+    root = Path(path)
+
+    for file in root.rglob("*"):
+        rel = file.relative_to(root)
+        if not file.is_file():
+            continue
+        if not any(fnmatch.fnmatch(str(rel), pattern) for pattern in include):
+            continue
+        if any(fnmatch.fnmatch(str(rel), pattern) for pattern in exclude):
+            continue
+        if is_binary_path(file):
+            continue
+        try:
+            stat = file.stat()
+            if not os.access(file, os.R_OK):
+                continue
+            if stat.st_size > max_size:
+                continue
+        except OSError:
+            continue
+        files.append(FileInfo(path=rel, size=stat.st_size, mtime=stat.st_mtime))
+    return files

--- a/tests/golden/dump.txt
+++ b/tests/golden/dump.txt
@@ -1,0 +1,5 @@
+# Uithub-local dump – sample – 2024-01-01T00:00:00+00:00
+# ≈ 1 tokens
+
+### a.txt
+hello

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import io
+import zipfile
+import responses
+from click.testing import CliRunner
+
+from uithub_local.cli import main
+
+
+def test_cli_basic(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hello")
+    runner = CliRunner()
+    result = runner.invoke(main, [str(tmp_path)])
+    assert result.exit_code == 0
+    assert "hello" in result.output
+
+
+def test_cli_outfile(tmp_path: Path):
+
+    (tmp_path / "a.txt").write_text("hello")
+    outfile = tmp_path / "out.txt"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [str(tmp_path), "--outfile", str(outfile), "--no-stdout"],
+    )
+    assert result.exit_code == 0
+    assert outfile.read_text()
+
+
+@responses.activate
+def test_cli_remote(tmp_path: Path):
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("repo-main/a.txt", "hello")
+    buf.seek(0)
+    url = "https://github.com/user/repo"
+    zip_url = "https://github.com/user/repo/archive/refs/heads/main.zip"
+    responses.add(responses.GET, zip_url, body=buf.getvalue(), status=200)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--remote-url", url, "--no-stdout"])
+    assert result.exit_code == 0

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,30 @@
+import io
+import zipfile
+
+import responses
+
+from uithub_local.downloader import download_repo, _zip_url
+
+
+@responses.activate
+def test_download_repo(tmp_path):
+    # Create in-memory zip
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("repo-main/hello.txt", "hi")
+    buf.seek(0)
+
+    url = "https://github.com/user/repo"
+    zip_url = "https://github.com/user/repo/archive/refs/heads/main.zip"
+    responses.add(responses.GET, zip_url, body=buf.getvalue(), status=200)
+
+    with download_repo(url) as path:
+        assert (path / "hello.txt").read_text() == "hi"
+
+
+def test_zip_url_variants():
+    assert _zip_url("user/repo").startswith("https://github.com/user/repo")
+    assert _zip_url("https://bitbucket.org/team/proj.git").endswith("/get/main.zip")
+    assert _zip_url("user/private", private=True).startswith(
+        "https://api.github.com/repos/user/private/zipball/"
+    )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,14 @@
+def test_load_text_success(tmp_path):
+    from uithub_local.loader import load_text
+
+    p = tmp_path / "a.txt"
+    p.write_text("hi")
+    assert load_text(p) == "hi"
+
+
+def test_load_text_fallback(tmp_path):
+    from uithub_local.loader import load_text
+
+    p = tmp_path / "b.txt"
+    p.write_bytes(b"\xff\xfe\xfd")
+    assert load_text(p)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from freezegun import freeze_time
+
+from uithub_local.renderer import render
+from uithub_local.walker import collect_files
+from uithub_local.tokenizer import approximate_tokens
+
+
+golden = Path(__file__).parent / "golden" / "dump.txt"
+
+
+@freeze_time("2024-01-01T00:00:00+00:00")
+def test_render_text(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hello")
+    files = collect_files(tmp_path, ["*"], [])
+    output = render(files, tmp_path)
+    expected = golden.read_text().strip()
+    # Replace repo name 'sample' with actual tmp dir name
+    expected = expected.replace("sample", tmp_path.name)
+    assert output.strip() == expected
+
+
+@freeze_time("2024-01-01T00:00:00+00:00")
+def test_render_json(tmp_path: Path):
+    import json
+
+    (tmp_path / "a.txt").write_text("hello")
+    files = collect_files(tmp_path, ["*"], [])
+    output = render(files, tmp_path, fmt="json")
+    data = json.loads(output)
+    assert data["repo"] == tmp_path.name
+    assert data["total_tokens"] > 0
+
+
+@freeze_time("2024-01-01T00:00:00+00:00")
+def test_render_truncate(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("a" * 100)
+    (tmp_path / "b.txt").write_text("b" * 100)
+    files = collect_files(tmp_path, ["*.txt"], [])
+    # limit tokens to roughly one file
+    output = render(files, tmp_path, max_tokens=approximate_tokens("a" * 100))
+    assert "a.txt" in output
+    assert "b.txt" not in output

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from uithub_local.tokenizer import approximate_tokens, total_tokens
+
+
+def test_approximate_tokens():
+    assert approximate_tokens("abcd") >= 1
+
+
+def test_total_tokens(tmp_path: Path):
+    p = tmp_path / "a.txt"
+    p.write_text("hello")
+    assert total_tokens([p]) >= 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+def test_is_binary_path(tmp_path):
+    from uithub_local.utils import is_binary_path
+
+    text = tmp_path / "a.txt"
+    text.write_text("hello")
+    binary = tmp_path / "b.bin"
+    binary.write_bytes(b"\0\1")
+    assert not is_binary_path(text)
+    assert is_binary_path(binary)
+
+    noisy = tmp_path / "c.bin"
+    noisy.write_bytes(b"A" * 6000 + b"\xff" * 3000)
+    assert is_binary_path(noisy)

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,0 +1,22 @@
+def test_collect_files_exclude_binary(tmp_path):
+    from uithub_local.walker import collect_files
+
+    (tmp_path / "bin").write_bytes(b"\0\1")
+    (tmp_path / "a.txt").write_text("hi")
+    files = collect_files(tmp_path, ["*"], [])
+    assert len(files) == 1
+    assert files[0].path.name == "a.txt"
+
+
+def test_collect_files_skip_large(tmp_path):
+    from uithub_local.walker import collect_files, DEFAULT_MAX_SIZE
+
+    big = tmp_path / "big.txt"
+    big.write_bytes(b"x" * (DEFAULT_MAX_SIZE + 1))
+    small = tmp_path / "small.txt"
+    small.write_text("hi")
+
+    files = collect_files(tmp_path, ["*"], [], max_size=DEFAULT_MAX_SIZE)
+    names = {f.path.name for f in files}
+    assert "small.txt" in names
+    assert "big.txt" not in names


### PR DESCRIPTION
## Summary
- support downloading remote repositories with private token
- filter large files in walker and expose --max-size option
- add downloader helper and tests
- improve binary detection heuristic
- document remote repo usage and tests
- add Makefile test target and optional dependencies

## Rationale
Incorporate code review feedback to handle private Git repos, skip large files earlier, provide dev tooling, and refine binary file detection.

## Tests Added
- unit tests for downloader variations
- fallback encoding in loader
- large-file skip in walker
- remote URL invocation of CLI
- enhanced binary detection

## Manual QA
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest -q`
- `python -m build --wheel`
- `pip install dist/uithub_local-0.1.0-py3-none-any.whl --force-reinstall`
- `uithub --help`


------
https://chatgpt.com/codex/tasks/task_e_686b004b4eac8328829db17705e218ef