### PR TITLE
feat: add max-size filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ uithub --remote-url https://github.com/owner/repo
 
 ## Usage
 
-Run `uithub --help` for all options. The dump can be printed to STDOUT or saved to a file. JSON output is available using `--format json`. Remote repositories can be processed with `--remote-url`; provide `--private-token` or set `GITHUB_TOKEN` for private repos.
+Run `uithub --help` for all options. The dump can be printed to STDOUT or saved to a file. JSON output is available using `--format json`. Remote repositories can be processed with `--remote-url`; provide `--private-token` or set `GITHUB_TOKEN` for private repos. Use `--max-size` to skip files larger than the given number of bytes (default 1048576).

--- a/src/uithub_local/loader.py
+++ b/src/uithub_local/loader.py
@@ -5,16 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 
-MAX_SIZE = 1_048_576  # 1 MiB
-
-
 def load_text(path: Path) -> str:
-    """Return text of *path*, skipping files larger than ``MAX_SIZE``.
-
-    Text is read with UTF-8 and fallback to ``errors='replace'``.
-    """
-    if path.stat().st_size > MAX_SIZE:
-        raise ValueError("File too large")
+    """Return text of *path* with UTF-8 fallback."""
 
     try:
         return path.read_text(encoding="utf-8")

--- a/src/uithub_local/renderer.py
+++ b/src/uithub_local/renderer.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
 
-from .loader import MAX_SIZE, load_text
+from .loader import load_text
 from .tokenizer import approximate_tokens
 from .walker import FileInfo
 
@@ -21,13 +21,12 @@ class FileDump:
         self.size = info.size
         self.tokens = 0
         self.content = ""
-        if self.size <= MAX_SIZE:
-            try:
-                self.content = load_text(self.full_path)
-                self.tokens = approximate_tokens(self.content)
-            except Exception:
-                self.content = ""
-                self.tokens = 0
+        try:
+            self.content = load_text(self.full_path)
+            self.tokens = approximate_tokens(self.content)
+        except Exception:
+            self.content = ""
+            self.tokens = 0
 
 
 class Dump:
@@ -46,7 +45,7 @@ class Dump:
     def _truncate(self, limit: int) -> None:
         self.file_dumps.sort(key=lambda f: f.tokens, reverse=True)
         while self.total_tokens > limit and self.file_dumps:
-            victim = self.file_dumps.pop()
+            victim = self.file_dumps.pop(0)
             self.total_tokens -= victim.tokens
 
     def as_text(self, repo_name: str) -> str:

--- a/src/uithub_local/walker.py
+++ b/src/uithub_local/walker.py
@@ -10,6 +10,8 @@ from typing import Iterable, List
 
 from .utils import is_binary_path
 
+DEFAULT_MAX_SIZE = 1_048_576
+
 
 @dataclass
 class FileInfo:
@@ -24,6 +26,7 @@ def collect_files(
     path: Path,
     include: Iterable[str] | None = None,
     exclude: Iterable[str] | None = None,
+    max_size: int = DEFAULT_MAX_SIZE,
 ) -> List[FileInfo]:
     """Return list of readable, non-binary files under *path*.
 
@@ -35,6 +38,8 @@ def collect_files(
         Glob patterns to include.
     exclude:
         Glob patterns to exclude.
+    max_size:
+        Skip files larger than this number of bytes.
     """
     include = list(include or ["*"])
     exclude = list(exclude or [])
@@ -56,6 +61,8 @@ def collect_files(
             if not os.access(file, os.R_OK):
                 continue
         except OSError:
+            continue
+        if stat.st_size > max_size:
             continue
         files.append(FileInfo(path=rel, size=stat.st_size, mtime=stat.st_mtime))
     return files

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,23 @@ def test_cli_outfile(tmp_path: Path):
     assert outfile.read_text()
 
 
+def test_cli_max_size(tmp_path: Path):
+    from uithub_local.walker import DEFAULT_MAX_SIZE
+
+    big = tmp_path / "big.txt"
+    big.write_bytes(b"x" * (DEFAULT_MAX_SIZE + 1))
+    (tmp_path / "small.txt").write_text("ok")
+    runner = CliRunner()
+    result = runner.invoke(main, [str(tmp_path)])
+    assert result.exit_code == 0
+    assert "big.txt" not in result.output
+    result = runner.invoke(
+        main, [str(tmp_path), "--max-size", str(DEFAULT_MAX_SIZE * 2)]
+    )
+    assert result.exit_code == 0
+    assert "big.txt" in result.output
+
+
 @responses.activate
 def test_cli_remote(tmp_path: Path):
     data = io.BytesIO()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,14 +1,3 @@
-def test_load_text_skip_large(tmp_path):
-    from uithub_local.loader import load_text, MAX_SIZE
-
-    p = tmp_path / "big.txt"
-    p.write_bytes(b"a" * (MAX_SIZE + 1))
-    import pytest
-
-    with pytest.raises(ValueError):
-        load_text(p)
-
-
 def test_load_text_success(tmp_path):
     from uithub_local.loader import load_text
 

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -6,3 +6,15 @@ def test_collect_files_exclude_binary(tmp_path):
     files = collect_files(tmp_path, ["*"], [])
     assert len(files) == 1
     assert files[0].path.name == "a.txt"
+
+
+def test_collect_files_respects_max_size(tmp_path):
+    from uithub_local.walker import collect_files, DEFAULT_MAX_SIZE
+
+    big = tmp_path / "big.txt"
+    big.write_bytes(b"x" * (DEFAULT_MAX_SIZE + 1))
+    small = tmp_path / "a.txt"
+    small.write_text("hi")
+    files = collect_files(tmp_path, ["*"], [], max_size=DEFAULT_MAX_SIZE)
+    names = {f.path.name for f in files}
+    assert names == {"a.txt"}


### PR DESCRIPTION
## Summary
- skip large files in `collect_files`
- add `--max-size` CLI option
- remove size limit from `loader`
- fix truncation order bug
- adjust tests and docs

## Rationale
- filtering big files earlier avoids heavy IO and matches CLI expectations
- exposes size filtering to users via CLI
- loader no longer needs a hardcoded size constant
- truncation should remove the largest file first for determinism

## Tests Added
- unit tests for max-size handling in `collect_files` and CLI

## QA Steps
- `ruff check`
- `black --check`
- `mypy src/uithub_local`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b08f056c48328b49cfcc2fc9109b8