### PR TITLE
feat: html renderer and binary detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ uithub --remote-url https://github.com/owner/repo
 
 ## Usage
 
-Run `uithub --help` for all options. The dump can be printed to STDOUT or saved to a file. JSON output is available using `--format json`. Remote repositories can be processed with `--remote-url`; provide `--private-token` or set `GITHUB_TOKEN` for private repos. Use `--max-size` to skip files larger than the given number of bytes (default 1048576).
+Run `uithub --help` for all options. The dump can be printed to STDOUT or saved to a file. JSON output is available using `--format json`. Use `--format html` for a self-contained HTML dump with collapsible sections. Remote repositories can be processed with `--remote-url`; provide `--private-token` or set `GITHUB_TOKEN` for private repos. Use `--max-size` to skip files larger than the given number of bytes (default 1048576).
 
 ### Running the test-suite
 
@@ -21,7 +21,7 @@ Install development dependencies and run tests:
 
 ```bash
 pip install .[test]
-uithub-local.test
+python -m pytest
 ```
 
 ### Adjusting file size limit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,16 @@ dependencies = [
     "tiktoken>=0.5",
 ]
 
-[project.optional-dependencies.test]
-freezegun = ">=1.4"
-responses = ">=0.25"
-pytest = "*"
-pytest-cov = "*"
+[project.optional-dependencies]
+test = [
+    "freezegun>=1.4",
+    "responses>=0.25",
+    "pytest",
+    "pytest-cov",
+]
 
 [project.scripts]
 uithub = "uithub_local.cli:main"
-test = "pytest --cov=uithub_local -q"
 
 [tool.black]
 line-length = 88

--- a/src/uithub_local/utils.py
+++ b/src/uithub_local/utils.py
@@ -5,15 +5,25 @@ from __future__ import annotations
 import mimetypes
 from pathlib import Path
 
+ASCII_WHITELIST = set(b"\t\n\r")
 
-def is_binary_path(path: Path) -> bool:
+
+def is_binary_path(path: Path, *, strict: bool = True) -> bool:
     """Return True if file looks binary."""
     mime, _ = mimetypes.guess_type(path.as_posix())
     if mime is not None and not mime.startswith("text"):
         return True
     try:
         with open(path, "rb") as fh:
-            chunk = fh.read(1024)
-        return b"\0" in chunk
+            chunk = fh.read(8192)
+        if b"\0" in chunk:
+            return True
+        if strict and chunk:
+            non_text = sum(
+                1 for b in chunk if not (32 <= b <= 126 or b in ASCII_WHITELIST)
+            )
+            if non_text / len(chunk) > 0.30:
+                return True
+        return False
     except OSError:
         return True

--- a/src/uithub_local/walker.py
+++ b/src/uithub_local/walker.py
@@ -27,6 +27,8 @@ def collect_files(
     include: Iterable[str] | None = None,
     exclude: Iterable[str] | None = None,
     max_size: int = DEFAULT_MAX_SIZE,
+    *,
+    binary_strict: bool = True,
 ) -> List[FileInfo]:
     """Return list of readable, non-binary files under *path*.
 
@@ -40,6 +42,8 @@ def collect_files(
         Glob patterns to exclude.
     max_size:
         Skip files larger than this number of bytes.
+    binary_strict:
+        Use strict binary detection.
     """
     include = list(include or ["*"])
     exclude = list(exclude or [])
@@ -54,7 +58,7 @@ def collect_files(
             continue
         if any(fnmatch.fnmatch(str(rel), pattern) for pattern in exclude):
             continue
-        if is_binary_path(file):
+        if is_binary_path(file, strict=binary_strict):
             continue
         try:
             stat = file.stat()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,3 +65,20 @@ def test_cli_remote(tmp_path: Path):
         ["--remote-url", "https://github.com/foo/bar", "--no-stdout"],
     )
     assert result.exit_code == 0
+
+
+def test_cli_no_binary_strict(tmp_path: Path):
+    noisy = tmp_path / "n.txt"
+    noisy.write_bytes(b"\x80" * 40 + b"a" * 10)
+    runner = CliRunner()
+    result = runner.invoke(main, [str(tmp_path), "--no-binary-strict"])
+    assert result.exit_code == 0
+    assert "n.txt" in result.output
+
+
+def test_cli_html(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hello")
+    runner = CliRunner()
+    result = runner.invoke(main, [str(tmp_path), "--format", "html"])
+    assert result.exit_code == 0
+    assert "<details>" in result.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,3 +7,12 @@ def test_is_binary_path(tmp_path):
     binary.write_bytes(b"\0\1")
     assert not is_binary_path(text)
     assert is_binary_path(binary)
+
+
+def test_is_binary_path_high_ascii(tmp_path):
+    from uithub_local.utils import is_binary_path
+
+    noisy = tmp_path / "noise.txt"
+    noisy.write_bytes(b"\x80" * 40 + b"a" * 10)
+    assert is_binary_path(noisy)
+    assert not is_binary_path(noisy, strict=False)


### PR DESCRIPTION
## Summary
- remove invalid `test` entrypoint and document running tests
- add optional `--format html` output
- add strict binary detection with `--binary-strict/--no-binary-strict`
- support Windows paths in renderer
- document HTML format in README
- update tests for HTML, binary detection, and Windows paths

## Rationale
- provide self-contained HTML dumps for convenient browsing
- improve binary detection with high-ASCII heuristic
- fix packaging by removing invalid script
- ensure compatibility with Windows path separators

## Tests Added
- HTML rendering output
- binary detection with noisy files
- Windows path rendering
- CLI options for HTML and non-strict mode

## Manual QA
- `ruff check .`
- `black --check .`
- `mypy src/uithub_local`
- `pytest --cov=uithub_local -q`


------
https://chatgpt.com/codex/tasks/task_e_686b0cb94d308328be8f4695cb9b1106