### PR TITLE
feat: polish HTML export and expose dump_repo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ uithub --remote-url https://github.com/owner/repo
 
 Run `uithub --help` for all options. The dump can be printed to STDOUT or saved to a file. JSON output is available using `--format json`. Use `--format html` for a self-contained HTML dump with collapsible sections. Remote repositories can be processed with `--remote-url`; provide `--private-token` or set `GITHUB_TOKEN` for private repos. Use `--max-size` to skip files larger than the given number of bytes (default 1048576).
 
+To save an HTML dump and open it in your default browser:
+
+```bash
+uithub path/to/repo --format html --outfile dump.html && xdg-open dump.html
+```
+
 ### Running the test-suite
 
 Install development dependencies and run tests:
@@ -31,3 +37,13 @@ The `--max-size` option expects bytes. Raise it if needed, e.g.:
 ```bash
 uithub path/to/repo --max-size $((2 * 1048576))
 ```
+
+## Changelog
+
+### 0.1.1
+- HTML export improvements (lang attribute, mobile viewport, truncated summaries).
+- Programmatic `dump_repo` helper function.
+- Coverage gate at 90%.
+
+### 0.1.0
+- Initial release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,21 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uithub-local"
-version = "0.1.0"
+version = "0.1.1"
 description = "Local Uithub CLI to flatten Git repositories into text dumps."
 authors = [{name = "Codex", email = "codex@example.com"}]
+license = {text = "MIT"}
+keywords = ["llm", "rag", "context", "github"]
 requires-python = ">=3.11"
 dependencies = [
     "click>=8",
     "tiktoken>=0.5",
+]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 
 [project.optional-dependencies]
@@ -36,4 +44,4 @@ python_version = "3.11"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=uithub_local -q"
+addopts = "--cov=uithub_local --cov-fail-under=90 -q"

--- a/src/uithub_local/__init__.py
+++ b/src/uithub_local/__init__.py
@@ -1,5 +1,7 @@
 """Local Uithub package."""
 
+from .api import dump_repo
+
 __all__ = [
     "cli",
     "loader",
@@ -7,4 +9,5 @@ __all__ = [
     "tokenizer",
     "walker",
     "downloader",
+    "dump_repo",
 ]

--- a/src/uithub_local/api.py
+++ b/src/uithub_local/api.py
@@ -1,0 +1,54 @@
+"""High-level programmatic API for uithub-local."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .downloader import download_repo
+from .renderer import render
+from .walker import DEFAULT_MAX_SIZE, collect_files
+
+
+def dump_repo(path_or_url: str | Path, *, fmt: str = "text", **cli_kwargs: Any) -> str:
+    """Return a repository dump as a string.
+
+    Parameters
+    ----------
+    path_or_url:
+        Local directory or remote repository URL.
+    fmt:
+        Output format ("text", "json" or "html").
+    **cli_kwargs:
+        Extra options matching the CLI, such as ``include``, ``exclude``,
+        ``max_size``, ``max_tokens``, ``binary_strict`` and ``private_token``.
+    """
+
+    include = cli_kwargs.get("include", ["*"])
+    exclude = cli_kwargs.get("exclude", [])
+    max_size = cli_kwargs.get("max_size", DEFAULT_MAX_SIZE)
+    max_tokens = cli_kwargs.get("max_tokens")
+    binary_strict = cli_kwargs.get("binary_strict", True)
+    private_token = cli_kwargs.get("private_token")
+
+    path = Path(path_or_url)
+    if path.exists():
+        files = collect_files(
+            path,
+            include,
+            exclude,
+            max_size=max_size,
+            binary_strict=binary_strict,
+        )
+        return render(files, path, max_tokens=max_tokens, fmt=fmt)
+
+    url = str(path_or_url)
+    with download_repo(url, private_token) as tmp:
+        files = collect_files(
+            tmp,
+            include,
+            exclude,
+            max_size=max_size,
+            binary_strict=binary_strict,
+        )
+        return render(files, tmp, max_tokens=max_tokens, fmt=fmt)

--- a/src/uithub_local/renderer.py
+++ b/src/uithub_local/renderer.py
@@ -81,14 +81,15 @@ class Dump:
             "<style>"
             "body{font-family:monospace;white-space:pre-wrap;}"
             "details{margin-bottom:1em;}"
-            "summary{font-weight:bold;cursor:pointer;}"
+            "summary{font-weight:bold;cursor:pointer;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block;}"
             "</style>"
         )
         lines = [
             "<!DOCTYPE html>",
-            "<html>",
+            '<html lang="en">',
             "<head>",
             '<meta charset="UTF-8">',
+            '<meta name="viewport" content="width=device-width,initial-scale=1">',
             f"<title>{repo_name} dump</title>",
             style,
             "</head>",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from uithub_local import dump_repo
+
+
+def test_dump_repo(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hi")
+    output = dump_repo(tmp_path, fmt="text")
+    assert "hi" in output


### PR DESCRIPTION
## Summary
- add programmatic `dump_repo` helper
- improve HTML export with mobile meta and ellipsis for long paths
- document HTML dump usage and add changelog
- add license/keywords/classifiers and coverage gate

## Rationale
- helper function allows library use without invoking CLI
- HTML output is now mobile-friendly and truncates long filenames
- metadata needed for release 0.1.1

## Tests Added
- unit test for `dump_repo`

## Manual QA
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b0fdda37c832883a49e169171ecca