### PR TITLE
fix: utf-8 file writes and encoding flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ To save an HTML dump and open it in your default browser:
 uithub path/to/repo --format html --outfile dump.html && xdg-open dump.html
 ```
 
+Save a plain text dump with explicit encoding:
+
+```bash
+uithub path/to/repo --outfile dump.txt --encoding utf-8
+```
+
 ### Running the test-suite
 
 Install development dependencies and run tests:
@@ -39,6 +45,10 @@ uithub path/to/repo --max-size $((2 * 1048576))
 ```
 
 ## Changelog
+
+### 0.1.2
+- Added ``--encoding`` option for file output.
+- Fixed UTF-8 writes when saving dumps.
 
 ### 0.1.1
 - HTML export improvements (lang attribute, mobile viewport, truncated summaries).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uithub-local"
-version = "0.1.1"
+version = "0.1.2"
 description = "Local Uithub CLI to flatten Git repositories into text dumps."
 authors = [{name = "Codex", email = "codex@example.com"}]
 license = {text = "MIT"}

--- a/src/uithub_local/api.py
+++ b/src/uithub_local/api.py
@@ -10,7 +10,13 @@ from .renderer import render
 from .walker import DEFAULT_MAX_SIZE, collect_files
 
 
-def dump_repo(path_or_url: str | Path, *, fmt: str = "text", **cli_kwargs: Any) -> str:
+def dump_repo(
+    path_or_url: str | Path,
+    *,
+    fmt: str = "text",
+    encoding: str = "utf-8",
+    **cli_kwargs: Any,
+) -> str:
     """Return a repository dump as a string.
 
     Parameters
@@ -19,9 +25,13 @@ def dump_repo(path_or_url: str | Path, *, fmt: str = "text", **cli_kwargs: Any) 
         Local directory or remote repository URL.
     fmt:
         Output format ("text", "json" or "html").
+    encoding:
+        Encoding to use when writing the returned dump to disk.
     **cli_kwargs:
         Extra options matching the CLI, such as ``include``, ``exclude``,
         ``max_size``, ``max_tokens``, ``binary_strict`` and ``private_token``.
+    This function does not write to disk. Callers can write the returned
+    string using ``Path.write_text(output, encoding=encoding)``.
     """
 
     include = cli_kwargs.get("include", ["*"])

--- a/src/uithub_local/cli.py
+++ b/src/uithub_local/cli.py
@@ -43,6 +43,12 @@ from .downloader import download_repo
 )
 @click.option("--stdout/--no-stdout", default=True, help="Print dump to STDOUT")
 @click.option("--outfile", type=click.Path(path_type=Path), help="Write dump to file")
+@click.option(
+    "--encoding",
+    default="utf-8",
+    show_default=True,
+    help="Encoding for --outfile",
+)
 @click.version_option()
 def main(
     path: Path | None,
@@ -56,6 +62,7 @@ def main(
     binary_strict: bool,
     stdout: bool,
     outfile: Path | None,
+    encoding: str,
 ) -> None:
     """Flatten a repository into one text dump."""
     if remote_url and path:
@@ -88,7 +95,7 @@ def main(
         raise SystemExit(1)
 
     if outfile:
-        outfile.write_text(output)
+        outfile.write_text(output, encoding=encoding, errors="replace")
     if stdout:
         click.echo(output)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,27 @@ def test_cli_outfile(tmp_path: Path):
     assert outfile.read_text()
 
 
+def test_cli_outfile_utf8(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hi")
+    out = tmp_path / "out.txt"
+    runner = CliRunner()
+    result = runner.invoke(main, [str(tmp_path), "--outfile", str(out)])
+    assert result.exit_code == 0
+    assert out.read_text(encoding="utf-8").startswith("# Uithub-local")
+
+
+def test_cli_outfile_cp1252(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hi")
+    out = tmp_path / "o.txt"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [str(tmp_path), "--outfile", str(out), "--encoding", "cp1252", "--no-stdout"],
+    )
+    assert result.exit_code == 0
+    assert out.read_text(encoding="cp1252").startswith("# Uithub-local")
+
+
 def test_cli_max_size(tmp_path: Path):
     from uithub_local.walker import DEFAULT_MAX_SIZE
 


### PR DESCRIPTION
## Summary
- ensure files are written with selected encoding
- allow `--encoding` in CLI and document in README
- expose `encoding` kwarg in `dump_repo`
- test writing dumps with utf-8 and cp1252
- bump version to 0.1.2

## Rationale
Writing dumps relied on the system default encoding which caused failures on
Windows. This patch makes file output UTF‑8 by default and lets users choose a
specific encoding if needed.

## Tests Added
- CLI outfile written with UTF‑8
- CLI outfile written with cp1252

## QA Steps
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b14d76ae48328a4dd5c0bc6816657