### PR TITLE
feat: improve exclude handling and default git ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Flatten a local Git repository into a single text dump with an approximate token
 ```bash
 pip install .
 
-uithub path/to/repo --include "*.py" --exclude "tests/*"
+# exclude entire directories with trailing slashes
+uithub path/to/repo --include "*.py" --exclude "tests/" 
 uithub --remote-url https://github.com/owner/repo
 ```
 
 ## Usage
 
 Run `uithub --help` for all options. The dump can be printed to STDOUT or saved to a file. JSON output is available using `--format json`. Use `--format html` for a self-contained HTML dump with collapsible sections. Remote repositories can be processed with `--remote-url`; provide `--private-token` or set `GITHUB_TOKEN` for private repos. Use `--max-size` to skip files larger than the given number of bytes (default 1048576).
+`.git/` directories are skipped automatically unless explicitly included.
 
 To save an HTML dump and open it in your default browser:
 
@@ -46,6 +48,10 @@ uithub path/to/repo --max-size $((2 * 1048576))
 
 ## Changelog
 
+### 0.1.3
+- Directory patterns now match recursively ("dir/" excludes everything under it).
+- `.git/` is excluded automatically unless explicitly included.
+- Correct repo name shown when dumping `.`.
 ### 0.1.2
 - Added ``--encoding`` option for file output.
 - Fixed UTF-8 writes when saving dumps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uithub-local"
-version = "0.1.2"
+version = "0.1.3"
 description = "Local Uithub CLI to flatten Git repositories into text dumps."
 authors = [{name = "Codex", email = "codex@example.com"}]
 license = {text = "MIT"}

--- a/src/uithub_local/cli.py
+++ b/src/uithub_local/cli.py
@@ -20,8 +20,20 @@ from .downloader import download_repo
 )
 @click.option("--remote-url", help="Git repo URL to download")
 @click.option("--private-token", envvar="GITHUB_TOKEN", help="Token for private repos")
-@click.option("--include", multiple=True, default=["*"], help="Glob(s) to include")
-@click.option("--exclude", multiple=True, help="Glob(s) to exclude")
+@click.option(
+    "--include",
+    multiple=True,
+    default=["*"],
+    help="Glob(s) to include. Directory names include everything below them.",
+)
+@click.option(
+    "--exclude",
+    multiple=True,
+    help=(
+        "Glob(s) to exclude. Directory names exclude everything below them. "
+        "'.git/' is excluded by default."
+    ),
+)
 @click.option(
     "--max-size",
     type=int,

--- a/src/uithub_local/renderer.py
+++ b/src/uithub_local/renderer.py
@@ -116,7 +116,8 @@ def render(
     fmt: str = "text",
 ) -> str:
     dump = Dump(files, root, max_tokens)
-    repo_name = root.name
+    resolved = root.resolve()
+    repo_name = resolved.name or resolved.parent.name
     if fmt == "json":
         return dump.as_json(repo_name)
     if fmt == "html":

--- a/src/uithub_local/walker.py
+++ b/src/uithub_local/walker.py
@@ -50,6 +50,21 @@ def collect_files(
     files: List[FileInfo] = []
     root = Path(path)
 
+    def expand(pattern: str) -> str:
+        if pattern.endswith(os.sep) or pattern in {"*", "**"}:
+            return pattern
+        if (root / pattern).is_dir():
+            return f"{pattern}/**"
+        return pattern
+
+    include = [expand(p) for p in include]
+    exclude = [expand(p) for p in exclude]
+
+    if (root / ".git").is_dir():
+        git_included = any(pat.lstrip("./").startswith(".git") for pat in include)
+        if not git_included:
+            exclude.append(".git/**")
+
     for file in root.rglob("*"):
         rel = file.relative_to(root)
         if not file.is_file():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,3 +103,24 @@ def test_cli_html(tmp_path: Path):
     result = runner.invoke(main, [str(tmp_path), "--format", "html"])
     assert result.exit_code == 0
     assert "<details>" in result.output
+
+
+def test_cli_exclude_directory(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "data").write_text("x")
+    (tmp_path / "a.txt").write_text("hi")
+    runner = CliRunner()
+    result = runner.invoke(main, [str(tmp_path), "--exclude", ".git"])
+    assert result.exit_code == 0
+    assert ".git/data" not in result.output
+    assert "a.txt" in result.output
+
+
+def test_cli_auto_excludes_git(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "config").write_text("x")
+    (tmp_path / "a.txt").write_text("hi")
+    runner = CliRunner()
+    result = runner.invoke(main, [str(tmp_path)])
+    assert result.exit_code == 0
+    assert ".git/config" not in result.output

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -63,3 +63,12 @@ def test_render_windows_paths(tmp_path: Path, path_cls):
     files = [FileInfo(path_cls(f.path.as_posix()), f.size, f.mtime) for f in files]
     output = render(files, tmp_path)
     assert "a.txt" in output
+
+
+@freeze_time("2024-01-01T00:00:00+00:00")
+def test_render_repo_name_dot(tmp_path: Path, monkeypatch):
+    (tmp_path / "a.txt").write_text("hi")
+    monkeypatch.chdir(tmp_path)
+    files = collect_files(Path("."), ["*"], [])
+    output = render(files, Path("."))
+    assert tmp_path.name in output.splitlines()[0]

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -18,3 +18,16 @@ def test_collect_files_respects_max_size(tmp_path):
     files = collect_files(tmp_path, ["*"], [], max_size=DEFAULT_MAX_SIZE)
     names = {f.path.name for f in files}
     assert names == {"a.txt"}
+
+
+def test_collect_files_exclude_dir(tmp_path):
+    from uithub_local.walker import collect_files
+
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "config").write_text("x")
+    (tmp_path / "a.txt").write_text("hi")
+    files = collect_files(tmp_path, ["*"], [".git"])
+    names = {f.path.as_posix() for f in files}
+    assert "a.txt" in names
+    assert not any(n.startswith(".git/") for n in names)


### PR DESCRIPTION
## Summary
- treat directory arguments to `--include/--exclude` as recursive
- auto-ignore `.git/` at repo root
- show repository directory name when dumping `.`
- update CLI help and docs
- bump version to 0.1.3
- expand tests to cover new behaviour

## Rationale
- Directory-wide exclude semantics are more intuitive
- `.git` contents should be skipped by default
- Correct repo name makes dumps clearer

## Tests Added
- walker handles directory excludes and git folder
- CLI ignores `.git/` and supports explicit exclusion
- renderer header uses current folder name for `.`

## Manual QA
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b183dd32c8328ba6859e2fa58904b