### PR TITLE
fix: normalize walker comment

### DIFF
--- a/src/uithub_local/walker.py
+++ b/src/uithub_local/walker.py
@@ -51,7 +51,7 @@ def collect_files(
     root = Path(path)
 
     def _expand(pattern: str) -> str:
-        # normalise platform separators
+        # normalize platform separators
         pat = pattern.replace("\\", "/").rstrip("/")
         if pat in {"*", "**"}:
             return pat


### PR DESCRIPTION
## Summary
- fix spelling in a walker helper comment

## Rationale
- keep terminology consistent with rest of codebase

## Testing
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b1f10b2a48328a87799e3b371e538