### PR TITLE
fix: support scp-style Git URLs

### DIFF
--- a/src/uithub_local/downloader.py
+++ b/src/uithub_local/downloader.py
@@ -57,15 +57,21 @@ def _archive_url(url: str) -> str:
         return url
 
     parsed = urllib.parse.urlparse(url)
-    if parsed.scheme in {"http", "https"}:
-        host = parsed.netloc
-        path = parsed.path
-        if path.endswith(".git"):
-            path = path[:-4]
-        slug = path.strip("/")
-    else:
+    host = parsed.hostname
+    path = parsed.path
+
+    if host is None and "@" in url and ":" in url:
+        user_host, path = url.split(":", 1)
+        host = user_host.split("@")[-1]
+
+    if not host:
         host = "github.com"
-        slug = url.strip("/")
+        if not path:
+            path = url
+
+    if path.endswith(".git"):
+        path = path[:-4]
+    slug = path.strip("/")
 
     if host.endswith("github.com"):
         return f"https://api.github.com/repos/{slug}/zipball"

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -68,3 +68,8 @@ def test_archive_url_gitlab_and_zip():
     assert gitlab == "https://gitlab.com/foo/bar/-/archive/master/bar-master.zip"
     direct = _archive_url("https://example.com/archive.zip")
     assert direct == "https://example.com/archive.zip"
+
+
+def test_archive_url_scp_style():
+    url = _archive_url("git@github.com:foo/bar.git")
+    assert url == "https://api.github.com/repos/foo/bar/zipball"


### PR DESCRIPTION
## Summary
- handle `git@host:user/repo.git` URLs correctly in `_archive_url`
- add regression test for scp-style URL handling

## Rationale
- `git@github.com:foo/bar.git` URLs were parsed incorrectly leading to bad API URLs

## Tests Added
- `test_archive_url_scp_style` verifies proper parsing

## Manual QA
- `ruff check`
- `black --check`
- `mypy src/uithub_local`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686b1f2154dc8328b8370443a29b3198