### PR TITLE
test: validate remote output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,9 +83,11 @@ def test_cli_remote(tmp_path: Path):
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["--remote-url", "https://github.com/foo/bar", "--no-stdout"],
+        ["--remote-url", "https://github.com/foo/bar"],
     )
     assert result.exit_code == 0
+    assert "file.txt" in result.output
+    assert "hi" in result.output
 
 
 def test_cli_no_binary_strict(tmp_path: Path):


### PR DESCRIPTION
## Changes
- ensure remote CLI output includes downloaded file content

## Rationale
`test_cli_remote` previously only checked the exit code. Verifying the dump ensures `download_repo` and rendering succeed.

## Tests Added
- updated `test_cli_remote` to assert file content is present in CLI output

## Manual QA Steps
- `ruff check`
- `black --check`
- `mypy src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686b1f4049a88328a9e4009cddb2cd94