### PR TITLE
fix: declare requests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
     "click>=8",
     "tiktoken>=0.5",
+    "requests>=2",
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary
- list `requests` in runtime dependencies for downloader

## Rationale
- `download_repo` uses the `requests` library but it wasn't included in project dependencies, causing runtime failures in installed packages

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b2021a5a48328a19a9763747e9bbf