### PR TITLE
docs: clarify test run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ uithub path/to/repo --outfile dump.txt --encoding utf-8
 
 ### Running the test-suite
 
-Install development dependencies and run tests:
+Install development dependencies and run tests with coverage:
 
 ```bash
 pip install .[test]
-python -m pytest
+pytest --cov=uithub_local -q
 ```
 
 ### Adjusting file size limit


### PR DESCRIPTION
## Summary
- update README section for running tests

## Rationale
- README instructed running pytest directly but tooling requires coverage

## Testing
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest --cov=uithub_local -q`

------
https://chatgpt.com/codex/tasks/task_e_686b204769588328b7bb7545ed593f75