### PR TITLE
test: assert full details tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Flatten a local Git repository into a single text dump with an approximate token count.
 
+## About
+Uithub-local packages repository contents into plain text, JSON or HTML dumps. Use it to prep code for large-context LLMs or save lightweight archives.
+
 ## Quick Start
 
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,7 +104,7 @@ def test_cli_html(tmp_path: Path):
     runner = CliRunner()
     result = runner.invoke(main, [str(tmp_path), "--format", "html"])
     assert result.exit_code == 0
-    assert "<details>" in result.output
+    assert "<details class='file-card'>" in result.output
 
 
 def test_cli_exclude_directory(tmp_path: Path):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -51,7 +51,7 @@ def test_render_html(tmp_path: Path):
     files = collect_files(tmp_path, ["*"], [])
     output = render(files, tmp_path, fmt="html")
     assert "<h1>Uithub-local dump" in output
-    assert "<details>" in output
+    assert "<details class='file-card'>" in output
     assert "hello" in output
 
 


### PR DESCRIPTION
## Summary
- check for `<details class='file-card'>` in CLI and renderer tests

## Rationale
- ensure markup check matches rendered HTML exactly

## Testing
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c022d2398832888e0f44f427fe79e