### PR TITLE
fix: skip unreadable files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__/
 *.py[cod]
 .venv/
-.egg-info/
+*.egg-info/
 build/
 dist/
 *.coverage

--- a/src/uithub_local/walker.py
+++ b/src/uithub_local/walker.py
@@ -68,23 +68,23 @@ def collect_files(
             exclude.append(".git/**")
 
     for file in root.rglob("*"):
-        rel = file.relative_to(root)
-        rel_path = str(rel).replace("\\", "/")
-        if not file.is_file():
-            continue
-        if not any(fnmatch.fnmatch(rel_path, pattern) for pattern in include):
-            continue
-        if any(fnmatch.fnmatch(rel_path, pattern) for pattern in exclude):
-            continue
-        if is_binary_path(file, strict=binary_strict):
-            continue
         try:
+            rel = file.relative_to(root)
+            rel_path = str(rel).replace("\\", "/")
+            if not file.is_file():
+                continue
+            if not any(fnmatch.fnmatch(rel_path, pattern) for pattern in include):
+                continue
+            if any(fnmatch.fnmatch(rel_path, pattern) for pattern in exclude):
+                continue
+            if is_binary_path(file, strict=binary_strict):
+                continue
             stat = file.stat()
             if not os.access(file, os.R_OK):
                 continue
+            if stat.st_size > max_size:
+                continue
+            files.append(FileInfo(path=rel, size=stat.st_size, mtime=stat.st_mtime))
         except OSError:
             continue
-        if stat.st_size > max_size:
-            continue
-        files.append(FileInfo(path=rel, size=stat.st_size, mtime=stat.st_mtime))
     return files


### PR DESCRIPTION
## Summary
- avoid exceptions when traversing unreadable files
- ignore egg-info folders anywhere in repo

## Rationale
`uithub-local` failed on Windows when encountering inaccessible symlinks like `.venv/lib64`. The walker now wraps file checks in `try/except` so such paths are skipped gracefully.

## Testing
- `ruff check`
- `black --check .`
- `mypy src/uithub_local`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687503122f048328860ad1bd05a60385